### PR TITLE
Declare FHIR version (extension for future versions)

### DIFF
--- a/extension-fhir.md
+++ b/extension-fhir.md
@@ -5,37 +5,44 @@ _This document is part of the [BioCompute Object specification](bco-specificatio
 
 The external references **example** extension to FHIR resource demonstrates how specific data elements can be extracted from EHR systems or other secure FHIR endpoints via technologies such as SMART on FHIR Genomics (https://www.ncbi.nlm.nih.gov/pubmed/26198304) without compromising patient and providers’ information. This is because the portions being transferred contain no identifiable information about the patient. Instead there is a reference to the actual resource instance (via FHIR URL) through which all data is accessed.
 
-`fhir_endpoint_resource` is a string containing the type of resource used. A full list of permitted FHIR resources is available at http://hl7.org/fhir/resourcelist.html. `fhir_endpoint` is an array of strings containing the URL of the endpoint of the FHIR server containing the resource. `fhir_endpoint_ids` is a string containing the server-specific identifier for the resource instance. The link to FHIR can also be added to the usability domain.  More on FHIR Genomics in release 3 of FHIR can be found here: https://www.hl7.org/fhir/genomics.html
+The `fhir_extension` is defined as an array of endpoints from which to fetch resources. 
+
+`fhir_endpoint` is a string containing the URL of the endpoint of the FHIR server containing the resource. `fhir_version` must be present showing the FHIR version used.
+
+`fhir_resources` is an array of resources to fetch from the endpoint, where `fhir_resource` is a string containing the type of resource used according to the specified version. (a full list of permitted FHIR 3 resources is available at http://hl7.org/fhir/STU3/resourcelist.html) `fhir_id` is a string containing the server-specific identifier for the resource instance. 
+
+The link to FHIR can also be added to the usability domain.  More on FHIR Genomics in release 3 of FHIR can be found here: https://www.hl7.org/fhir/genomics.html
 
 SMART on FHIR Genomics provides a framework for EHR-based apps built on FHIR that integrate clinical and genomic information. For more information on how to use the SMART on FHIR Genomics apps, please visit http://projects.iq.harvard.edu/smartgenomics/.   
 
 ```json
     "extension_domain":{
         "fhir_extension": [
-            {
-                "fhir_endpoint_resource": "Sequence",
-                "fhir_endpoint_url": "http://fhirtest.uhn.ca/baseDstu3",
-                "fhir_endpoint_ids": ["21376"]
-            },
-            {
-                "fhir_endpoint_resource": "DiagnosticReport",
-                "fhir_endpoint_url": "http://fhirtest.uhn.ca/baseDstu3",
-                "fhir_endpoint_ids": ["6288583"]
-            },
-            {
-                "fhir_endpoint_resource": "ProcedureRequest",
-                "fhir_endpoint_url": "http://fhirtest.uhn.ca/baseDstu3",
-                "fhir_endpoint_ids": ["25544"]
-            },
-            {
-                "fhir_endpoint_resource": "Observation",
-                "fhir_endpoint_url": "http://fhirtest.uhn.ca/baseDstu3",
-                "fhir_endpoint_ids": ["92440"]
-            },
-            {
-                "fhir_endpoint_resource": "FamilyMemberHistory",
-                "fhir_endpoint_url": "http://fhirtest.uhn.ca/baseDstu3",
-                "fhir_endpoint_ids": ["4588936"]
+            { "fhir_endpoint": "http://fhirtest.uhn.ca/baseDstu3",
+              "fhir_version": "3",
+              "fhrir_resources": [
+                {
+                    "fhir_resource": "Sequence",
+                    "fhir_id": "21376"
+                },
+                {
+                    "fhir_resource": "DiagnosticReport",
+                    "fhir_id": "6288583"
+                },
+                {
+                    "fhir_resource": "ProcedureRequest",
+                    "fhir_id": "25544"
+                },
+                {
+                    "fhir_resource": "Observation",
+                    "fhir_id": "92440"
+                },
+                {
+                    "fhir_resource": "FamilyMemberHistory",
+                    "fhir_id": "4588936"
+                }
+              ]
             }
-        ],	
+        ]
+    }
 ```


### PR DESCRIPTION
Suggested changes to [extension-fhir.md](https://github.com/biocompute-objects/BCO_Specification/blob/fhir_restructure/extension-fhir.md#231-extension-to-external-references-smart-on-fhir-genomics)

Nest list of resources under list of (now versioned) endpoints.


TODO: Update JSON schema accordingly. Remove enums for `fhir_endpoint_resource` as the list would change for FHIR 4 (and 5, 6, ...)