### PR TITLE
Define a bco specific `uri` object

### DIFF
--- a/HCV1a.json
+++ b/HCV1a.json
@@ -1,6 +1,6 @@
 {
     "bco_id": "https://github.com/biocompute-objects/BCO_Specification/blob/master/HCV1a.json",
-    "digital_signature": "0B61E7C0EFF537CADADE475AA6386262FCDBC4DC",
+    "checksum": "0B61E7C0EFF537CADADE475AA6386262FCDBC4DC",
     "bco_spec_version" : "https://w3id.org/biocompute/spec/v1.2",
     "provenance_domain": {
         "name": "HCV1a ledipasvir resistance SNP detection", 

--- a/HCV1a.json
+++ b/HCV1a.json
@@ -140,52 +140,52 @@
                     {
                         "name": "Hepatitis C virus genotype 1", 
                         "uri": {
-                            "address": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
+                            "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     }, 
                     {
                         "name": "Hepatitis C virus type 1b complete genome", 
                         "uri": {
-                            "address": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
+                            "uri": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     }, 
                     {
                         "name": "Hepatitis C virus (isolate JFH-1) genomic RNA", 
                         "uri": {
-                            "address": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
+                            "uri": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     }, 
                     {
                         "name": "Hepatitis C virus clone J8CF, complete genome", 
                         "uri": {
-                            "address": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
+                            "uri": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     }, 
                     {
                         "name": "Hepatitis C virus S52 polyprotein gene", 
                         "uri": {
-                            "address": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
+                            "uri": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     }
                 ], 
                 "input_list": [
                     {
-                        "address": "http://example.com/dna.cgi?cmd=objFile&ids=514683",
+                        "uri": "http://example.com/dna.cgi?cmd=objFile&ids=514683",
                         "access_time": "2017-01-24T09:40:17-0500"
                     }, 
                     {
-                        "address": "http://example.com/dna.cgi?cmd=objFile&ids=514682",
+                        "uri": "http://example.com/dna.cgi?cmd=objFile&ids=514682",
                         "access_time": "2017-01-24T09:40:17-0500"
                     }
                 ],
                 "output_list": [
                     {
-                        "address": "http://example.com/data/514769/allCount-aligned.csv",
+                        "uri": "http://example.com/data/514769/allCount-aligned.csv",
                         "access_time": "2017-01-24T09:40:17-0500"
                     }
                 ]
@@ -197,17 +197,17 @@
                 "version": "1.3", 
                 "input_list": [
                     {
-                        "address": "http://example.com/data/514769/dnaAccessionBased.csv",
+                        "uri": "http://example.com/data/514769/dnaAccessionBased.csv",
                         "access_time": "2017-01-24T09:40:17-0500"
                     }
                 ], 
                 "output_list": [
                     {
-                        "address": "http://example.com/data/514801/SNPProfile.csv",
+                        "uri": "http://example.com/data/514801/SNPProfile.csv",
                         "access_time": "2017-01-24T09:40:17-0500"
                     }, 
                     {
-                        "address": "http://example.com/data/14769/allCount-aligned.csv",
+                        "uri": "http://example.com/data/14769/allCount-aligned.csv",
                         "access_time": "2017-01-24T09:40:17-0500"
                     }
                 ]
@@ -224,7 +224,7 @@
                 "name": "HIVE-hexagon", 
                 "version": "babajanian.1",
                 "uri": {
-                    "address": "http://example.com/dna.cgi?cmd=dna-hexagon&cmdMode=-",
+                    "uri": "http://example.com/dna.cgi?cmd=dna-hexagon&cmdMode=-",
                     "access_time": "2017-01-24T09:40:17-0500",
                     "sha1_chksum": "d60f506cddac09e9e816531e7905ca1ca6641e3c"
                 }
@@ -233,7 +233,7 @@
                 "name": "HIVE-heptagon", 
                 "version": "albinoni.2",
                 "uri": {
-                    "address": "http://example.com/dna.cgi?cmd=dna-heptagon&cmdMode=-",
+                    "uri": "http://example.com/dna.cgi?cmd=dna-heptagon&cmdMode=-",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }
@@ -263,51 +263,51 @@
     "io_domain": {
         "input_subdomain": [
             {
-                "name": "Hepatitis C virus genotype 1", 
                 "uri": {
-                    "address": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
+                    "filename": "Hepatitis C virus genotype 1", 
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }, 
             {
-                "name": "Hepatitis C virus type 1b complete genome", 
                 "uri": {
-                    "address": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
+                    "filename": "Hepatitis C virus type 1b complete genome", 
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }, 
             {
-                "name": "Hepatitis C virus (isolate JFH-1) genomic RNA", 
                 "uri": {
-                    "address": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
+                    "filename": "Hepatitis C virus (isolate JFH-1) genomic RNA", 
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }, 
             {
-                "name": "Hepatitis C virus clone J8CF, complete genome", 
                 "uri": {
-                    "address": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }, 
             {
-                "name": "Hepatitis C virus S52 polyprotein gene", 
                 "uri": {
-                    "address": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
+                    "filename": "Hepatitis C virus S52 polyprotein gene", 
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             },
             {
-                "name": "HCV1a_drug_resistant_sample0001-01", 
                 "uri": {
-                    "address": "http://example.com/nuc-read/514682",
+                    "filename": "HCV1a_drug_resistant_sample0001-01", 
+                    "uri": "http://example.com/nuc-read/514682",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }, 
             {
-                "name": "HCV1a_drug_resistant_sample0001-02", 
+ 
                 "uri": {
-                    "address": "http://example.com/nuc-read/514683",
+                    "filename": "HCV1a_drug_resistant_sample0001-02",
+                    "uri": "http://example.com/nuc-read/514683",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }
@@ -316,14 +316,14 @@
             {
                 "mediatype": "text/csv", 
                 "uri": { 
-                    "address": "http://example.com/data/514769/dnaAccessionBased.csv",
+                    "uri": "http://example.com/data/514769/dnaAccessionBased.csv",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             },
             {
                 "mediatype": "text/csv", 
                 "uri": {
-                    "address": "http://example.com/data/514801/SNPProfile*.csv",
+                    "uri": "http://example.com/data/514801/SNPProfile*.csv",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }

--- a/HCV1a.json
+++ b/HCV1a.json
@@ -9,6 +9,7 @@
             {
                 "status": "approved",
                 "reviewer_comment": "Approved by GW staff. Waiting for approval from FDA Reviewer",
+                "date": "2017-11-12T12:30:48-0400",
                 "reviewer": {
                     "name": "Charles Hadley King", 
                     "affiliation": "George Washington University", 
@@ -20,6 +21,7 @@
             {
                 "status": "approved",
                 "reviewer_comment": "The revised BCO looks fine",
+                "date": "2017-12-12T12:30:48-0400",
                 "reviewer": {
                     "name": "Eric Donaldson", 
                     "affiliation": "FDA", 

--- a/HCV1a.json
+++ b/HCV1a.json
@@ -1,7 +1,7 @@
 {
-    "bco_id": "https://github.com/biocompute-objects/BCO_Specification/blob/master/HCV1a.json",
+    "bco_id": "https://w3id.org/biocompute/examples/HCV1a.json",
     "checksum": "0B61E7C0EFF537CADADE475AA6386262FCDBC4DC",
-    "bco_spec_version" : "https://w3id.org/biocompute/spec/v1.2",
+    "bco_spec_version" : "https://w3id.org/biocompute/spec/1.3.0",
     "provenance_domain": {
         "name": "HCV1a ledipasvir resistance SNP detection", 
         "version": "2.9",

--- a/HCV1a.json
+++ b/HCV1a.json
@@ -215,8 +215,9 @@
         ]
     },
     "execution_domain": {
-        "script_access_type": "URI",
-        "script": ["https://example.com/workflows/antiviral_resistance_detection_hive.py"],
+        "script": {
+			"uri": "https://example.com/workflows/antiviral_resistance_detection_hive.py"
+		},
         "script_driver": "shell", 
         "software_prerequisites": [
             {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To facilitate a means for different stakeholders in the HTS communities to provi
 
 ## User Guide 
 
-The [BioCompute Objects user guide](/schema/user_guide.md) provides an introduction to implementing/writing a BCO for a pipeline and/or a workflow, and is taken from the [BioCompute Objects Specification Document](/bco-specification.md).
+The [BioCompute Objects user guide](/user_guide.md) provides an introduction to implementing/writing a BCO for a pipeline and/or a workflow, and is taken from the [BioCompute Objects Specification Document](/IEEE_Docs/standard.md).
 
 ### Repository
 
@@ -28,7 +28,7 @@ Note that unless you are viewing a [release](https://github.com/biocompute-objec
 
 Table of content:
 
-* [BioCompute Object (BCO) specification document](bco-specification.md)
+* [BioCompute Object (BCO) specification document](user_guide.md)
   * [Introduction to BioCompute Objects](introduction.md)
   * [BCO domains](bco-domains.md)
     * [Top level fields](top-level.md)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 BioCompute
 ==========
 
-Main website: http://biocomputeobject.org/
+BioCompute Partnership: http://biocomputeobject.org
 
 GitHub repository for BioCompute Objects:
 https://github.com/biocompute-objects/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note that unless you are viewing a [release](https://github.com/biocompute-objec
 
 Table of content:
 
-* [BioCompute Object (BCO) specification document](user_guide.md)
+* [BioCompute Object (BCO) User Guide](user_guide.md)
   * [Introduction to BioCompute Objects](introduction.md)
   * [BCO domains](bco-domains.md)
     * [Top level fields](top-level.md)

--- a/bco-domains.md
+++ b/bco-domains.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 # BCO domains
 

--- a/bco-domains.md
+++ b/bco-domains.md
@@ -66,7 +66,7 @@ Specification:
 
 ## 2.3 Extension Domain "extension_domain"
 
-The `extension_domain` is a space for a user to add more structured information that is defined in the BCO type definition. The `extension_domain` section is not evaluated by checks for BCO validity or computational correctness and as such is the place to add *ANY* type of additional **structured** information. We provide two examples that are neither exclusive or exhaustive.
+The `extension_domain` is a space for a user to add additional structured information that is not defined in the BioCompute shcema. The `extension_domain` section is not evaluated by checks for BCO validity or computational correctness and as such is the place to add *ANY* type of additional **structured** information. We provide two examples that are neither exclusive or exhaustive.
 
 Specifications:
 

--- a/bco-domains.md
+++ b/bco-domains.md
@@ -11,7 +11,7 @@ Condensed example:
     "bco_spec_version" : "https://w3id.org/biocompute/spec/v1.2",
     "bco_id": "https://example.com/bco/9487ae7e-c1aa-4a3c-b18f-3d3695b33ace",
     "type": "antiviral_resistance_detection", 
-    "digital_signature": "584C7FE128717E1712426AB19CAAEA8BC1E27365B54285BBEA1221284C7D3A48",
+    "checksum": "584C7FE128717E1712426AB19CAAEA8BC1E27365B54285BBEA1221284C7D3A48",
     "provenance_domain": {
     },
     "usability_domain": [

--- a/description-domain.md
+++ b/description-domain.md
@@ -1,5 +1,7 @@
 _This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
+_Back to [BCO domains](bco-domains.md)_
+
 ## 2.4 Description Domain "description_domain"
 
 
@@ -10,7 +12,7 @@ Structured field for description of external references, the pipeline steps, and
 Condensed example:
 
 ```json
-"description_domain": {
+    "description_domain": {
         "keywords": [
         ], 
         "xref": [
@@ -18,7 +20,7 @@ Condensed example:
         "platform": ["HIVE"],
         "pipeline_steps": [
             {
-                "step_number": "1", 
+                "step_number": 1, 
                 "name": "HIVE-hexagon", 
                 "description": "Alignment of reads to a set of references", 
                 "version": "1.3", 
@@ -37,22 +39,22 @@ Condensed example:
                 ]
             }
         ]
-    
-},
+    }
 ```
 
 
 ### 2.4.1 Keywords "keywords"
 
-This is a list of keywords to aid in search-ability and description of the object. This is required. 
+This is a list of keywords to aid in search-ability and description of the experiment. This is required. 
 
 ```json
-        "keywords": [
-                        "HCV1a", 
-                        "Ledipasvir", 
-                        "antiviral resistance", 
-                        "SNP", 
-                        "amino acid substitutions"
+    "keywords": [
+        "HCV1a", 
+        "Ledipasvir", 
+        "antiviral resistance", 
+        "SNP", 
+        "amino acid substitutions"
+    ]
 ```
 
 ### 2.4.2 External References "xref"
@@ -88,7 +90,7 @@ This field contains a list of the databases and/or ontology IDs that are cross-r
                 "ids": ["31646"], 
                 "access_time": "2018-13-02T10:15-05:00"
             }
-        ], 
+        ] 
 ```
 
 ### 2.4.3 Platform/Environment "platform"
@@ -96,7 +98,7 @@ This field contains a list of the databases and/or ontology IDs that are cross-r
 The multi-value reference to a particular deployment of an existing platform where this BCO can be reproduced. A platform can be a bioinformatic platform such as Galaxy or HIVE or it can be a software package such as CASAVA or apps that includes multiple algorithms and software. This is for informative purposes only. 
 
 ```json
-"platform": ["HIVE"]
+    "platform": ["HIVE"]
 ```
 ### 2.4.4 Pipeline tools "pipeline_steps"
 
@@ -107,7 +109,7 @@ This is an optional structured domain for recording the specifics of a pipeline.
 This is a non-negative integer value representing the position of the tool in a one-dimensional representation of the pipeline. The number is a suggestion for a [partial order](https://en.wikipedia.org/wiki/Partially_ordered_set) for presentation purposes, e.g. parallel computations assigned the same number based on their first possible execution. Actual execution order might differ from the step number. Gaps are allowed (e.g. step 20 follows step 10). 
 
 ```json
-"step_number": 1
+    "step_number": 1
 ```
 
 #### 2.4.4.2 Name "name"
@@ -115,7 +117,7 @@ This is a non-negative integer value representing the position of the tool in a 
 Name for the specific tool. This field is a string (A-z, 0-1) and should be a single uniquely identifying word for the tool. 
 
 ```json
-"name": "HIVE-hexagon"
+    "name": "HIVE-hexagon"
 ```
 
 #### 2.4.4.2 Tool Description "description"
@@ -123,7 +125,7 @@ Name for the specific tool. This field is a string (A-z, 0-1) and should be a si
 A free text field for describing the specific use/purpose of the tool.
 
 ```json
-"description": "Alignment of reads to a set of references",
+    "description": "Alignment of reads to a set of references",
 ```
 
 #### 2.4.4.3 Tool Version "version"
@@ -131,51 +133,51 @@ A free text field for describing the specific use/purpose of the tool.
 The version assigned to the instance of the tool used corresponding to the upstream release.
 
 ```json
-"version": "1.3",
+    "version": "1.3",
 ```
 
 #### 2.4.4.4 Tool Prerequisites "prerequisite"
 
-A list of text values to indicate any packages or prerequisites for running the tool used. 
+A list of text values to indicate any packages or prerequisites for running the tool used. This consists of a `name` and `uri`. The `uri` object consists of the `filename`, `uri`, `access_time`, and `sha1_chksum` properties. The `uri` is the only REQUIRED property but it is reccomended that in the `prerequisites` here the `access_time` is used as well. 
 
 ```json
-                    "prerequisite": [
-                        {
-                            "name": "Hepatitis C virus genotype 1", 
-                            "uri": {
-                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
-                                "access_time": "2017-01-24T09:40:17-0500"
-                            }
-                        }, 
-                        {
-                            "name": "Hepatitis C virus type 1b complete genome", 
-                            "uri": {
-                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
-                                "access_time": "2017-01-24T09:40:17-0500"
-                            }
-                        }, 
-                        {
-                            "name": "Hepatitis C virus (isolate JFH-1) genomic RNA", 
-                            "uri": {
-                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
-                                "access_time": "2017-01-24T09:40:17-0500"
-                            }
-                        }, 
-                        {
-                            "name": "Hepatitis C virus clone J8CF, complete genome", 
-                            "uri": {
-                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
-                                "access_time": "2017-01-24T09:40:17-0500"
-                            }
-                        }, 
-                        {
-                            "name": "Hepatitis C virus S52 polyprotein gene", 
-                            "uri": {
-                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
-                                "access_time": "2017-01-24T09:40:17-0500"
-                            }
-                        }
-                    ]
+    "prerequisite": [
+        {
+            "name": "Hepatitis C virus genotype 1", 
+            "uri": {
+                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
+                "access_time": "2017-01-24T09:40:17-0500"
+            }
+        }, 
+        {
+            "name": "Hepatitis C virus type 1b complete genome", 
+            "uri": {
+                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
+                "access_time": "2017-01-24T09:40:17-0500"
+            }
+        }, 
+        {
+            "name": "Hepatitis C virus (isolate JFH-1) genomic RNA", 
+            "uri": {
+                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
+                "access_time": "2017-01-24T09:40:17-0500"
+            }
+        }, 
+        {
+            "name": "Hepatitis C virus clone J8CF, complete genome", 
+            "uri": {
+                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
+                "access_time": "2017-01-24T09:40:17-0500"
+            }
+        }, 
+        {
+            "name": "Hepatitis C virus S52 polyprotein gene", 
+            "uri": {
+                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
+                "access_time": "2017-01-24T09:40:17-0500"
+            }
+        }
+    ]
 ```
 
 #### 2.4.4.6 Input List "input_list"
@@ -183,16 +185,16 @@ A list of text values to indicate any packages or prerequisites for running the 
 Each tool lists the URIs (expressed as a URN or URL) of the input files. These are a catchall for read files, reference files or any other type of input. All of these fields are optional and for descriptive purposes, therefore the structure here is less rigid than in other fields. 
 
 ```json
-                    "input_list": [
-                        {
-                            "uri": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514683",
-                            "access_time": "2017-01-24T09:40:17-0500"
-                        }, 
-                        {
-                            "uri": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514682",
-                            "access_time": "2017-01-24T09:40:17-0500"
-                        }
-                    ],
+    "input_list": [
+        {
+            "uri": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514683",
+            "access_time": "2017-01-24T09:40:17-0500"
+        }, 
+        {
+            "uri": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514682",
+            "access_time": "2017-01-24T09:40:17-0500"
+        }
+    ],
 ```
 
 #### 2.4.4.7 Output List "output_list"
@@ -200,10 +202,10 @@ Each tool lists the URIs (expressed as a URN or URL) of the input files. These a
 Each tool lists the URIs (expressed as a URN or URL) of the output files for that tool. 
 
 ```json
-                    "output_list": [
-                        {
-                            "uri": "https://hive.biochemistry.gwu.edudata/514769/allCount-aligned.csv",
-                            "access_time": "2017-01-24T09:40:17-0500"
-                        }
-                    ]
+    "output_list": [
+        {
+            "uri": "https://hive.biochemistry.gwu.edudata/514769/allCount-aligned.csv",
+            "access_time": "2017-01-24T09:40:17-0500"
+        }
+    ]
 ```

--- a/description-domain.md
+++ b/description-domain.md
@@ -26,7 +26,7 @@ Condensed example:
                     {
                         "name": "Hepatitis C virus genotype 1", 
                         "uri": {
-                            "address": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
+                            "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     }
@@ -143,35 +143,35 @@ A list of text values to indicate any packages or prerequisites for running the 
                         {
                             "name": "Hepatitis C virus genotype 1", 
                             "uri": {
-                                "address": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
+                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
                                 "access_time": "2017-01-24T09:40:17-0500"
                             }
                         }, 
                         {
                             "name": "Hepatitis C virus type 1b complete genome", 
                             "uri": {
-                                "address": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
+                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
                                 "access_time": "2017-01-24T09:40:17-0500"
                             }
                         }, 
                         {
                             "name": "Hepatitis C virus (isolate JFH-1) genomic RNA", 
                             "uri": {
-                                "address": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
+                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/13122261",
                                 "access_time": "2017-01-24T09:40:17-0500"
                             }
                         }, 
                         {
                             "name": "Hepatitis C virus clone J8CF, complete genome", 
                             "uri": {
-                                "address": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
+                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/386646758",
                                 "access_time": "2017-01-24T09:40:17-0500"
                             }
                         }, 
                         {
                             "name": "Hepatitis C virus S52 polyprotein gene", 
                             "uri": {
-                                "address": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
+                                "uri": "http://www.ncbi.nlm.nih.gov/nuccore/295311559",
                                 "access_time": "2017-01-24T09:40:17-0500"
                             }
                         }
@@ -185,11 +185,11 @@ Each tool lists the URIs (expressed as a URN or URL) of the input files. These a
 ```json
                     "input_list": [
                         {
-                            "address": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514683",
+                            "uri": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514683",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }, 
                         {
-                            "address": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514682",
+                            "uri": "https://hive.biochemistry.gwu.edu/dna.cgi?cmd=objFile&ids=514682",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     ],
@@ -202,7 +202,7 @@ Each tool lists the URIs (expressed as a URN or URL) of the output files for tha
 ```json
                     "output_list": [
                         {
-                            "address": "https://hive.biochemistry.gwu.edudata/514769/allCount-aligned.csv",
+                            "uri": "https://hive.biochemistry.gwu.edudata/514769/allCount-aligned.csv",
                             "access_time": "2017-01-24T09:40:17-0500"
                         }
                     ]

--- a/description-domain.md
+++ b/description-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 2.4 Description Domain "description_domain"
 

--- a/error-domain.md
+++ b/error-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 
 ## 2.8 Error Domain, acceptable range of variability "error_domain"

--- a/execution-domain.md
+++ b/execution-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 2.5 Execution Domain "execution_domain"
 

--- a/execution-domain.md
+++ b/execution-domain.md
@@ -49,7 +49,7 @@ An optional multi-value field listing the minimal necessary prerequisites, libra
                 "name": "HIVE-hexagon", 
                 "version": "babajanian.1",
                 "uri": {
-                    "address": "http://example.com/dna.cgi?cmd=dna-hexagon&cmdMode=-",
+                    "uri": "http://example.com/dna.cgi?cmd=dna-hexagon&cmdMode=-",
                     "access_time": "2017-01-24T09:40:17-0500",
                     "sha1_chksum": "d60f506cddac09e9e816531e7905ca1ca6641e3c"
                 }
@@ -58,7 +58,7 @@ An optional multi-value field listing the minimal necessary prerequisites, libra
                 "name": "HIVE-heptagon", 
                 "version": "albinoni.2",
                 "uri": {
-                    "address": "http://example.com/dna.cgi?cmd=dna-heptagon&cmdMode=-",
+                    "uri": "http://example.com/dna.cgi?cmd=dna-heptagon&cmdMode=-",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }

--- a/execution-domain.md
+++ b/execution-domain.md
@@ -23,15 +23,7 @@ Condensed example:
 }
 ```
 
-### 2.5.1 Script Access Type "script_access_type"
-
-This field indicates whether the code of the "script" to execute the BioCompute Object is accessed as an external file via HTTP (URI) or in-line text in the `script` field. Valid options are `URI` or `text`.
-
-```json
- "script_access_type": "URI" OR "text"
- ```
-
-### 2.5.2 Script "script"
+### 2.5.1  Script "script"
 
 The Script field points to an internal or external reference to a script object that was used to perform computations for this BCO instance. This may be a reference to an object in GitHub, a computational service or any other type of script. 
 
@@ -39,7 +31,7 @@ The Script field points to an internal or external reference to a script object 
  "script": ["https://example.com/workflows/antiviral_resistance_detection_hive.py"]
 ```
 
-### 2.5.3 Script driver "script_driver"
+### 2.5.2 Script driver "script_driver"
 
 This field provides a space to indicate what kind of executable can be launched in order to perform a sequence of commands described in the script (see above) in order to run the pipeline. 
 
@@ -47,7 +39,7 @@ This field provides a space to indicate what kind of executable can be launched 
 "script_driver": "shell"
 ```
 
-### 2.5.4 Algorithmic tools and Software Prerequisites "software_prerequisites" 
+### 2.5.3 Algorithmic tools and Software Prerequisites "software_prerequisites" 
 
 An optional multi-value field listing the minimal necessary prerequisites, library, tool versions needed to successfully run the script to produce BCO. The keys are `name`, `version`, and `uri`. 
 
@@ -73,7 +65,7 @@ An optional multi-value field listing the minimal necessary prerequisites, libra
         ]
 ```
 
-### 2.5.5 External Data Endpoints "external_data_endpoints"
+### 2.5.4 External Data Endpoints "external_data_endpoints"
 
 An optional multi-value field listing the minimal necessary domain specific external data source access in order to successfully run the script to produce BCO. The values under this field present the requirements for network protocol endpoints used by a pipeline’s scripts, or other software. 
 
@@ -94,7 +86,7 @@ The key `name` should describe the service that is accessed.
 ]
 ```
 
-### 2.5.6 Environment Variables "environment_variables"
+### 2.5.5 Environment Variables "environment_variables"
 
 Multi-value additional key value pairs useful to configure the execution environment on the target platform. For example, one might specify the number of compute cores, or available memory use of the script. The possible keys are specific to each platform. The "value" should be a JSON string.
 

--- a/extension-fhir.md
+++ b/extension-fhir.md
@@ -1,5 +1,6 @@
-_This document is part of the [BioCompute Object User Guide](user_guide.md)_
+_This document is part of the [BioCompute Object specification](bco-specification.md)_
 
+_Back to [BCO domains](bco-domains.md)_
 
 ### 2.3.1 Extension to External References: SMART on FHIR Genomics
 
@@ -18,31 +19,30 @@ SMART on FHIR Genomics provides a framework for EHR-based apps built on FHIR tha
 ```json
     "extension_domain":{
         "fhir_extension": [
-            { "fhir_endpoint": "http://fhirtest.uhn.ca/baseDstu3",
-              "fhir_version": "3",
-              "fhrir_resources": [
-                {
-                    "fhir_resource": "Sequence",
-                    "fhir_id": "21376"
-                },
-                {
-                    "fhir_resource": "DiagnosticReport",
-                    "fhir_id": "6288583"
-                },
-                {
-                    "fhir_resource": "ProcedureRequest",
-                    "fhir_id": "25544"
-                },
-                {
-                    "fhir_resource": "Observation",
-                    "fhir_id": "92440"
-                },
-                {
-                    "fhir_resource": "FamilyMemberHistory",
-                    "fhir_id": "4588936"
-                }
-              ]
+            {
+                "fhir_endpoint": "http://fhirtest.uhn.ca/baseDstu3",
+                "fhir_version": "3",
+                "fhir_resources": [
+                    {
+                        "fhir_resource": "Sequence",
+                        "fhir_id": "21376"
+                    },
+                    {
+                        "fhir_resource": "DiagnosticReport",
+                        "fhir_id": "6288583"
+                    },
+                    {
+                        "fhir_resource": "ProcedureRequest",
+                        "fhir_id": "25544"
+                    },
+                    {
+                        "fhir_resource": "Observation",
+                        "fhir_id": "92440"
+                    },
+                    {
+                        "fhir_resource": "FamilyMemberHistory",
+                        "fhir_id": "4588936"
+                    }
+                ]
             }
-        ]
-    }
 ```

--- a/extension-fhir.md
+++ b/extension-fhir.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 
 ### 2.3.1 Extension to External References: SMART on FHIR Genomics

--- a/extension-scm.md
+++ b/extension-scm.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ### 2.3.2 Extension to External References: Software Configuration Management (SCM)
 

--- a/extension-scm.md
+++ b/extension-scm.md
@@ -1,5 +1,7 @@
 _This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
+_Back to [BCO domains](bco-domains.md)_
+
 ### 2.3.2 Extension to External References: Software Configuration Management (SCM)
 
 The external references **example** extension to a SCM repository demonstrates how a BioCompute Object software source code can be stored/deposited/downloaded. The BCO would contain links to the SCM repository where the information is stored and easily retrieved. The links to the SCM can be added to the usability domain as well.

--- a/external-references.md
+++ b/external-references.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 3.2 Appendix-II: External reference database list
 

--- a/introduction.md
+++ b/introduction.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 # 1 Introduction to BioCompute Objects
 

--- a/introduction.md
+++ b/introduction.md
@@ -2,7 +2,7 @@ _This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 # 1 Introduction to BioCompute Objects
 
-BioCompute is a paradigm and a BioCompute Object (BCO) is an instance of that paradigm. High-throughput sequencing (HTS), also referred to as next-generation sequencing (NGS) or massively parallel sequencing (MPS), has increased the pace at which we generate, compute and share genomic data in biomedical sciences. As a result, scientists, clinicians and regulators are now faced with a new data paradigm that is less portable, more complex and most of all poorly standardized. BCOs use a simple JSON format to encode important information on the execution of computational pipelines, or for the creation of knowledgebases. BioCompute can be process oriented (for software pipelines) and/or product oriented (for knowledge bases). So error domain can include information to do QA and/or QC. The goal of using a BCO is to streamline communication of these details between stakeholders in academia, industry and regulatory agencies. 
+BioCompute is a paradigm and a BioCompute Object (BCO) is an instance of that paradigm. High-throughput sequencing (HTS), also referred to as next-generation sequencing (NGS) or massively parallel sequencing (MPS), has increased the pace at which we generate, compute and share genomic data in biomedical sciences. As a result, scientists, clinicians and regulators are now faced with a new data paradigm that is less portable, more complex and most of all poorly standardized. BCOs use a simple implementation of the JSON schema to encode important information on the execution of computational pipelines, or for the creation of knowledgebases. BioCompute can be process oriented (for software pipelines) and/or product oriented (for knowledge bases). The goal of using a BCO is to streamline communication of these details between stakeholders in academia, industry and regulatory agencies. 
 
 The US Food and Drug Administration (FDA) and George Washington University (GW) have partnered to establish a framework for community-based standards development and harmonization of HTS computations and data formats. Standardized HTS data processing and data formats will promote interoperability and simplify the verification of bioinformatics protocols. To do this, a schema has been developed to represent instances of computational analysis as a BCO. A BCO includes: 
 
@@ -31,9 +31,7 @@ The unpredictability of tangible physical, chemical, and biological experiments 
 
  A BioCompute Object database record will be similar to a GenBank record in form; however, instead of describing a sequence, the BioCompute record will include information related to parameters, dependencies, usage, and other information related to the specific computational instance. This mechanism will extend similar efforts and also serve as a collaborative ground to ensure interoperability between different platforms, industries, scientists, regulators, and other stakeholders interested in biocomputing.
 
- 
-
-For more information, see the project description on the [FDA Extramural Research](https://www.fda.gov/ScienceResearch/SpecialTopics/RegulatoryScience/ucm227223.htm) page. 
+For more information, see the project description on the [FDA Extramural Research](https://wayback.archive-it.org/7993/20180126133504/https://www.fda.gov/ScienceResearch/SpecialTopics/RegulatoryScience/ucm491893.htm) page. 
 
 ### 1.2.1 Limitations of the initial effort
 
@@ -88,4 +86,4 @@ A BCO can be used to provide clarity and transparency of the data integration pr
 
 ## 1.6 BCO community
 
-The BioCompute Object working group facilitates a means for different stakeholders in the HTS communities to provide input on current practices on the BCO. This working group was formed during preparation for the 2017 HTS Computational Standards for Regulatory Sciences Workshop, and was initially made up of the workshop participants, both speakers and panelists. There has been a continual growth of the BCO working group as a direct result of the interaction between a variety of stakeholders from all interested communities in standardization of computational HTS data processing. 
+The BioCompute Object working group facilitates a means for different stakeholders in the HTS communities to provide input on current practices on the BCO. This working group was formed during preparation for the [2017 HTS Computational Standards for Regulatory Sciences Workshop](https://hive.biochemistry.gwu.edu/htscsrs/workshop_2017), and was initially made up of the workshop participants, both speakers and panelists. There has been a continual growth of the BCO working group as a direct result of the interaction between the stakeholders interested in standardization of computational HTS data processing. 

--- a/io-domain.md
+++ b/io-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 
 ## 2.7 Input and Output Domain "io_domain"

--- a/io-domain.md
+++ b/io-domain.md
@@ -23,39 +23,22 @@ Condensed exampled:
 This field records the references and input files for the entire pipeline. Each type of input file is listed under a key for that type. The file types are specified when the BCO type is created. This allows the author to be very specific about a particular type of input file, if they so choose. For example: reference files have common names, and adding the common name here, in addition to the uri would make this more readable and understandable (eg, `"HCV reference version..."` or `"human reference GRCH38"`). For data integration workflows, the input files can be a table downloaded from a specific source which is then filtered for modified using rules described in the BCO.
 
 ```json
-"input_subdomain": {
-    "subject": [
-        {
-            "name": "Hepatitis C virus genotype 1", 
-            "uri": {
-                "address": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
-                "access_time": "2017-01-24T09:40:17-0500"
+        "input_subdomain": [
+            {
+                "uri": {
+                    "filename": "Hepatitis C virus genotype 1", 
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/22129792",
+                    "access_time": "2017-01-24T09:40:17-0500"
+                }
+            }, 
+            {
+                "uri": {
+                    "filename": "Hepatitis C virus type 1b complete genome", 
+                    "uri": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
+                    "access_time": "2017-01-24T09:40:17-0500"
+                }
             }
-        }, 
-        {
-            "name": "Hepatitis C virus type 1b complete genome", 
-            "uri": {
-                "address": "http://www.ncbi.nlm.nih.gov/nuccore/5420376",
-                "access_time": "2017-01-24T09:40:17-0500"
-            }
-        }, 
-    "query": [
-        {
-            "name": "HCV1a_drug_resistant_sample0001-01", 
-            "uri": {
-                "address": "https://hive.biochemistry.gwu.edunuc-read/514682",
-                "access_time": "2017-01-24T09:40:17-0500"
-            }
-        }, 
-        {
-            "name": "HCV1a_drug_resistant_sample0001-02", 
-            "uri": {
-                "address": "https://hive.biochemistry.gwu.edunuc-read/514683",
-                "access_time": "2017-01-24T09:40:17-0500"
-            }
-        }
-    ]
-}
+        ]
 ```
 
 ### 2.7.2 Output Subdomain "output_subdomain"
@@ -67,18 +50,17 @@ This field records the outputs for the entire pipeline. Each file should be an o
             {
                 "mediatype": "text/csv", 
                 "uri": { 
-                    "address": "https://hive.biochemistry.gwu.edudata/514769/dnaAccessionBased.csv",
+                    "uri": "http://example.com/data/514769/dnaAccessionBased.csv",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
-            }, 
+            },
             {
                 "mediatype": "text/csv", 
                 "uri": {
-                    "address": "https://hive.biochemistry.gwu.edudata/514801/SNPProfile.csv",
+                    "uri": "http://example.com/data/514801/SNPProfile*.csv",
                     "access_time": "2017-01-24T09:40:17-0500"
                 }
             }
         ]
-    }
 ```
 

--- a/parametric-domain.md
+++ b/parametric-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 2.6 Parametric Domain "parametric_domain"
 

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 2.1 Provenance Domain "provenance_domain"
 

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -59,7 +59,7 @@ The "status" key describes the status of an object in the review process and the
 * `suspended` flag indicates an object that was once valid is no longer considered valid. 
 * `rejected` flag indicates that an error or inconsistency was detected in the BCO, and it has been removed or rejected. 
 
-The fields from the `contributor` object (described in [section 2.1.8](#2.1.8-contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
+The fields from the `contributor` object (described in [section 2.1.8](/provenance-domain.md#218-contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
 
 ```json
         "review": [

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -27,7 +27,7 @@ Condensed example:
 
 ### 2.1.1 Name "name"
 
-Name for the BCO. This public field should take free text value using common biological research terminology supporting the terminology used in the [`usability_domain`](usability_domain.md), external references ([xref](/description-domain.md#242-external-references-xref)), and [keywords](/description-domain.md#241-keywords-keywords) sections.
+Name for the BCO. This public field should take free text value using common biological research terminology supporting the terminology used in the [`usability_domain`](usability_domain.md), external references ([`xref`](/description-domain.md#242-external-references-xref)), and [`keywords`](/description-domain.md#241-keywords-keywords) sections.
 
 ```json
 "name": "HCV1a ledipasvir resistance SNP detection"

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -59,14 +59,14 @@ The "status" key describes the status of an object in the review process and the
 * `suspended` flag indicates an object that was once valid is no longer considered valid. 
 * `rejected` flag indicates that an error or inconsistency was detected in the BCO, and it has been removed or rejected. 
 
-The fields from the `contributor` object (described in [section 2.1.9](#2.1.8-Contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
+The fields from the `contributor` object (described in [section 2.1.8](#2.1.8-Contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
 
 ```json
         "review": [
             {
                 "status": "approved",
                 "reviewer_comment": "Approved by GW staff. Waiting for approval from FDA Reviewer",
-                "date": "2017-11-12T12:30:48-0400"
+                "date": "2017-11-12T12:30:48-0400",
                 "reviewer": {
                     "name": "Charles Hadley King", 
                     "affiliation": "George Washington University", 
@@ -78,7 +78,7 @@ The fields from the `contributor` object (described in [section 2.1.9](#2.1.8-Co
             {
                 "status": "approved",
                 "reviewer_comment": "The revised BCO looks fine",
-                "date": "2017-12-12T12:30:48-0400"
+                "date": "2017-12-12T12:30:48-0400",
                 "reviewer": {
                     "name": "Eric Donaldson", 
                     "affiliation": "FDA", 

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -1,4 +1,5 @@
 _This document is part of the [BioCompute Object User Guide](user_guide.md)_
+_[BCO domains](bco-domains.md)_
 
 ## 2.1 Provenance Domain "provenance_domain"
 

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -59,7 +59,7 @@ The "status" key describes the status of an object in the review process and the
 * `suspended` flag indicates an object that was once valid is no longer considered valid. 
 * `rejected` flag indicates that an error or inconsistency was detected in the BCO, and it has been removed or rejected. 
 
-The fields from the `contributor` object (described in [section 2.1.8](#2.1.8-Contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
+The fields from the `contributor` object (described in [section 2.1.8](#2.1.8-contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
 
 ```json
         "review": [

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -12,7 +12,6 @@ Condensed example:
         "version": "2.9",
         "review": [
         ],
-        "derived_from" : "https://github.com/biocompute-objects/BCO_Specification/blob/master/HCV1a.json",
         "obsolete_after" : "2118-09-26T14:43:43-0400",
         "embargo" : {
 	},
@@ -26,7 +25,7 @@ Condensed example:
 
 ### 2.1.1 Name "name"
 
-Name for the BCO. This public field should take free text value using common biological research terminology supporting external reference linkage identifiers whenever possible for use in the structured name.
+Name for the BCO. This public field should take free text value using common biological research terminology supporting the terminology used in the [`usability_domain`](usability_domain.md), external references ([xref](/description-domain.md#242-external-references-xref)), and [keywords](/description-domain.md#241-keywords-keywords) sections.
 
 ```json
 "name": "HCV1a ledipasvir resistance SNP detection"
@@ -43,17 +42,15 @@ Records the versioning of this BCO instance object. [Semantic Versioning 2.0.0](
 >3. PATCH version when you make backwards-compatible bug fixes.
 >Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
 
-In BCO versioning, a change in the BCO affecting the outcome of the computation **MAJOR** should be deposited as a new BCO, not as a new version. If a parameter in a tool is changed within a BCO, which in turn changes the outcome of the pipeline and the original BCO, a new BCO, not a new version, will be created. 
-
-In such cases the connection between the new object and the older one may or may not be (on author’s discretion) retained in the form of a reference using the [`derived_from`](provenance-domain.md#215-inheritancederivation-derived_from) field. Changes that cannot affect the results of the computation can be incorporated into a new version of the existing BCO (**MINOR** and **PATCH**). Such changes might include name and title, comments, authors, validity dates, etc. 
+BCO versioning should adhere to semantic versioning.
 
 ```json
-"version": "2.1",
+"version": "2.1.0",
 ```
 
 ### 2.1.3 Review "review"
 
-This is a list to hold reviewer identifiers and a description of the status of an object in the review process, including the subtype "reviewer", which contains field(s) for name, affiliation, email, and contribution of each reviewer. To further record author information, ORCID IDs are included as they allow for the author to curate their information after submission. ORCID identifiers must be valid and must have the prefix https://orcid.org/. The contribution type is a choice taken from PAV ontology: provenance, authoring and versioning, which also maps to the PROV-O.
+This is an array to hold reviewer identifiers and a description of the status of an object in the review process. The subtype `reviewer` contains field(s) for name, affiliation, email, and the contribution type of the reviewer. To further record author information, ORCID IDs are included as they allow for the author to curate their information after submission. ORCID identifiers must be valid and must have the prefix https://orcid.org/. The contribution type is a choice taken from PAV ontology: provenance, authoring and versioning, which also maps to the [PROV-O](https://www.w3.org/TR/prov-o/).
 
 The "status" key describes the status of an object in the review process and the following are the possible values: 
 * `unreviewed` flag indicates that the object has been submitted, but no further evaluation or verification has occurred.  
@@ -62,14 +59,14 @@ The "status" key describes the status of an object in the review process and the
 * `suspended` flag indicates an object that was once valid is no longer considered valid. 
 * `rejected` flag indicates that an error or inconsistency was detected in the BCO, and it has been removed or rejected. 
 
-The fields from the `contributor` object (described in section 2.1.10) is inherited to populate the reviewer section. 
+The fields from the `contributor` object (described in [section 2.1.9](#2.1.8-Contributors-contributors)) are used to populate the reviewer section. Each BCO MUST have at least one `review`. 
 
 ```json
         "review": [
             {
                 "status": "approved",
                 "reviewer_comment": "Approved by GW staff. Waiting for approval from FDA Reviewer",
-		"date": "2017-11-12T12:30:48-0400"
+                "date": "2017-11-12T12:30:48-0400"
                 "reviewer": {
                     "name": "Charles Hadley King", 
                     "affiliation": "George Washington University", 
@@ -81,7 +78,7 @@ The fields from the `contributor` object (described in section 2.1.10) is inheri
             {
                 "status": "approved",
                 "reviewer_comment": "The revised BCO looks fine",
-		"date": "2017-12-12T12:30:48-0400"
+                "date": "2017-12-12T12:30:48-0400"
                 "reviewer": {
                     "name": "Eric Donaldson", 
                     "affiliation": "FDA", 
@@ -92,15 +89,7 @@ The fields from the `contributor` object (described in section 2.1.10) is inheri
         ]
 ```
 
-### 2.1.4 Inheritance/derivation "derived_from"
-
-If the object is derived from another, this field will specify the parent object, in the form of the ‘bco_id’. If the object inherits only from the base BioCompute Object or a type definition than the field is not included. 
-
-```json
-"derived_from" : "https://github.com/biocompute-objects/BCO_Specification/blob/master/HCV1a.json",
-```
-
-### 2.1.6 Obsolescence "obsolete_after" 
+### 2.1.4 Obsolescence "obsolete_after" 
 
 If the object has an expiration date this field will specify that using the ‘datetime’ type which is in ISO-8601 format as clarified by W3C [https://www.w3.org/TR/NOTE-datetime](https://www.w3.org/TR/NOTE-datetime). This field is optional.
 
@@ -110,7 +99,7 @@ If the object has an expiration date this field will specify that using the ‘d
 
 ### 2.1.5 Embargo "embargo"
 
-If the object has a period of time that it is not public, that range can be specified using these fields.  Using the `datetime`’` type a start and end time are specified for the embargo. These fields are optional.
+If the object has a period of time that it is not public, that range can be specified using these fields.  Using the `datetime` type, a start and end time are specified for the embargo. These fields are optional.
 
 ```json
 "embargo" : {
@@ -121,7 +110,7 @@ If the object has a period of time that it is not public, that range can be spec
 
 ### 2.1.6 Created "created"
 
-Using the `datetime` type the time of initial creation of the BCO is recorded in ISO-8601 format as clarified by W3C [https://www.w3.org/TR/NOTE-datetime](https://www.w3.org/TR/NOTE-datetime).
+Using the `datetime` type the time of initial creation of the BCO is recorded in ISO-8601 format as clarified by W3C [https://www.w3.org/TR/NOTE-datetime](https://www.w3.org/TR/NOTE-datetime). This field should be `readOnly`. 
 
 ```json
 "created": "2017-01-20T09:40:17-0500"

--- a/provenance-domain.md
+++ b/provenance-domain.md
@@ -1,5 +1,6 @@
 _This document is part of the [BioCompute Object User Guide](user_guide.md)_
-_[BCO domains](bco-domains.md)_
+
+_Back to [BCO domains](bco-domains.md)_
 
 ## 2.1 Provenance Domain "provenance_domain"
 

--- a/schemas/biocomputeobject.json
+++ b/schemas/biocomputeobject.json
@@ -33,12 +33,16 @@
         "uri": {
             "$comment": "https://github.com/biocompute-objects/BCO_Specification/blob/1935b9c2765a3d00e44e338ead5b637a5b20b648/primitives.json#L41-L56",
             "type": "object",
+            "description": "TODO",
             "additionalProperties": false,
             "required": [
-                "address"
+                "uri"
             ],
             "properties": {
-                "address": {
+                "filename": {
+                    "type": "string"
+                },
+                "uri": {
                     "type": "string",
                     "format": "uri"
                 },
@@ -48,7 +52,7 @@
                 },
                 "sha1_chksum": {
                     "type": "string",
-                    "description": "Sha256 or any hash function that produces a message digest",
+                    "description": "hash function that produces a message digest",
                     "pattern": "[A-Za-z0-9]+"
                 }
             }

--- a/schemas/biocomputeobject.json
+++ b/schemas/biocomputeobject.json
@@ -7,7 +7,7 @@
     "required": [
         "bco_id",
         "bco_spec_version",
-        "digital_signature",
+        "checksum",
         "provenance_domain",
         "usability_domain",
         "description_domain",
@@ -68,7 +68,7 @@
             "readOnly": true,
             "format": "uri"
         },
-        "digital_signature": {
+        "checksum": {
             "type": "string",
             "description": "A string-type, read-only value, protecting the object from internal or external alterations without proper validation generated with a SHA-256 hash function.",
             "examples": [

--- a/schemas/biocomputeobject.json
+++ b/schemas/biocomputeobject.json
@@ -25,11 +25,6 @@
                 "https://github.com/biocompute-objects/BCO_Spec_V1.2/blob/master/HCV1a.json"
             ]
         },
-        "inherited": {
-            "$comment": "FIXME: how should schema(s) handle inherited types?",
-            "type": "object",
-            "description": "all fields in this domain are BioCompute specific and should be defined in inherited BioCompute type"
-        },
         "uri": {
             "$comment": "https://github.com/biocompute-objects/BCO_Specification/blob/1935b9c2765a3d00e44e338ead5b637a5b20b648/primitives.json#L41-L56",
             "type": "object",

--- a/schemas/execution_domain.json
+++ b/schemas/execution_domain.json
@@ -5,7 +5,6 @@
     "title": "The Execution_domain Schema",
     "description": "TODO",
     "required": [
-        "script_access_type",
         "script",
         "script_driver",
         "software_prerequisites",
@@ -14,24 +13,8 @@
     ],
     "additionalProperties": false,
     "properties": {
-        "script_access_type": {
-            "type": "string",
-            "enum": [
-                "URI",
-                "text"
-            ],
-            "description": "Indication of whether the code of the 'script' to execute the BioCompute Object is accessed as an external file via HTTP (URI) or in-line text in the script field."
-        },
         "script": {
-            "type": "array",
-            "description": "Points to internal or external references to a script object that was used to perform computations for this BCO instance",
-            "items": {
-                "type": "string",
-                "description": "An internal or external reference to a script object",
-                "examples": [
-                    "https://example.com/workflows/antiviral_resistance_detection_hive.py"
-                ]
-            }
+            "$ref": "biocomputeobject.json#/definitions/uri"
         },
         "script_driver": {
             "type": "string",

--- a/schemas/io_domain.json
+++ b/schemas/io_domain.json
@@ -8,61 +8,21 @@
         "input_subdomain",
         "output_subdomain"
     ],
-    "definitions": {
-        "uri": {
-            "$comment": "https://github.com/biocompute-objects/BCO_Specification/blob/1935b9c2765a3d00e44e338ead5b637a5b20b648/primitives.json#L41-L56",
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-                "address"
-            ],
-            "properties": {
-                "address": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "access_time": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "sha1_chksum": {
-                    "type": "string",
-                    "pattern": "[A-Za-z0-9]+"
-                }
-            }
-        },
-        "name": {
-            "type": "string",
-            "description": "human readable designition for the input",
-            "examples": [
-                "Hepatitis C virus genotype 1"
-            ],
-            "pattern": "^(.*)$"
-        }
-    },
     "properties": {
         "input_subdomain": {
             "type": "array",
             "title": "input_domain",
             "description": "A record of the references and input files for the entire pipeline. Each type of input file is listed under a key for that type.",
+            "$comment": "TODO: Need to find a way to specify 'filename' is required here.",
             "items": {
+                "additionalProperties": false,
                 "type": "object",
                 "required": [
-                    "name",
                     "uri"
                 ],
                 "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "human readable designition for the input",
-                        "examples": [
-                            "Hepatitis C virus genotype 1"
-                        ],
-                        "pattern": "^(.*)$"
-                    },
                     "uri": {
-                        "type": "object",
-                        "$ref": "#/definitions/uri"
+                        "$ref": "biocomputeobject.json#/definitions/uri"
                     }
                 }
             }
@@ -82,14 +42,14 @@
                     "mediatype": {
                         "type": "string",
                         "title": "mediatype",
+                        "description": "https://www.iana.org/assignments/media-types/",
                         "examples": [
                             "text/csv"
                         ],
                         "pattern": "^(.*)$"
                     },
                     "uri": {
-                        "type": "object",
-                        "$ref": "#/definitions/uri"
+                        "$ref": "biocomputeobject.json#/definitions/uri"
                     }
                 }
             }

--- a/top-level.md
+++ b/top-level.md
@@ -10,7 +10,7 @@ Condensed example:
 {
     "bco_spec_version" : "https://w3id.org/biocompute/spec/v1.2",
     "bco_id": "https://example.com/bco/9487ae7e-c1aa-4a3c-b18f-3d3695b33ace",
-    "digital_signature": "d41d8cd98f00b204e9800998ecf8427e",    
+    "checksum": "d41d8cd98f00b204e9800998ecf8427e",    
     "provenance_domain": {
     },
     "...": { }
@@ -33,9 +33,9 @@ A unique identifier that should be applied to each BCO instance. These can be as
 "bco_id": "https://github.com/biocompute-objects/BCO_Specification/blob/master/HCV1a.json"
 ```
 
-### 2.0.3 Digital signature "digital_signature"
+### 2.0.3 Checksum "checksum"
 
-A string-type, read-only value, protecting the object from internal or external alterations without proper validation. The string should be generated through the use of a SHA-256 hash function. Everything EXCEPT for the `digital_signature`, `bco_id` and `bco_spec_version` should be included in the generation of the hash. For example:
+A string-type, read-only value, protecting the object from internal or external alterations without proper validation. The string should be generated through the use of a SHA-256 hash function. Everything EXCEPT for the `checksum`, `bco_id` and `bco_spec_version` should be included in the generation of the hash. For example:
 
 ```json
     "provenance_domain": {},
@@ -50,7 +50,7 @@ A string-type, read-only value, protecting the object from internal or external 
 will generate the following:
 
 ```json
-"digital_signature": "584C7FE128717E1712426AB19CAAEA8BC1E27365B54285BBEA1221284C7D3A48"
+"checksum": "584C7FE128717E1712426AB19CAAEA8BC1E27365B54285BBEA1221284C7D3A48"
 ```
 
 ### Additional domains

--- a/top-level.md
+++ b/top-level.md
@@ -19,7 +19,7 @@ Condensed example:
 
 ### 2.0.1 BCO version "bco_spec_version"
 
-The version of the BCO specification used to define this document. It is recomended that this value be a permalink as defined in the [w3id.org/biocompute](https://github.com/perma-id/w3id.org/tree/master/biocompute) repository. 
+The version of the BCO specification used to define the BCO. It is recomended that this value be a permalink as defined in the [w3id.org/biocompute](https://github.com/perma-id/w3id.org/tree/master/biocompute) repository. 
 
 ```json
 "bco_spec_version": "https://w3id.org/biocompute/spec/v1.2" 
@@ -27,10 +27,10 @@ The version of the BCO specification used to define this document. It is recomen
 
 ### 2.0.2 BioCompute Object Identifier "bco_id"
 
-A unique identifier that should be applied to each BCO instance. These can be assigned by a BCO database engine. IDs should never be reused. It is RECOMMENDED that the BCO identifier is based on a [UUID](https://tools.ietf.org/html/rfc4122)s (sometimes called GUIDs) to ensure uniqueness, either as a location-independent URN (e.g. urn:uuid:2bf8397b-9aa8-47f2-80a7-235653e8e824) or as part of an identifier permalink, (e.g. http://repo.example.com/bco/2bf8397b-9aa8-47f2-80a7-235653e8e824). While the UUID is the preferred method, IDs expressed as a URN or URL are also acceptable.
+A unique identifier that should be applied to each BCO instance. These can be assigned by a BCO database engine or manualy generated. IDs should never be reused. It is RECOMMENDED that the BCO identifier is based on a [UUID](https://tools.ietf.org/html/rfc4122)s (sometimes called GUIDs) to ensure uniqueness, either as a location-independent URN (e.g. `urn:uuid:2bf8397b-9aa8-47f2-80a7-235653e8e824`) or as part of an identifier permalink, (e.g. `http://repo.example.com/bco/2bf8397b-9aa8-47f2-80a7-235653e8e824`). While the UUID is the preferred method, IDs expressed as a URN or URL are also acceptable.
 
 ```json
-"bco_id": "https://github.com/biocompute-objects/BCO_Specification/blob/master/HCV1a.json"
+"bco_id": "https://w3id.org/biocompute/examples/HCV1a.json"
 ```
 
 ### 2.0.3 Checksum "checksum"

--- a/top-level.md
+++ b/top-level.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 2.0 Top Level Fields
 

--- a/types-discontinued-BCO_Specification/data-typing.md
+++ b/types-discontinued-BCO_Specification/data-typing.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 3.4 Appendix V Data typing
 

--- a/usability-domain.md
+++ b/usability-domain.md
@@ -6,7 +6,7 @@ _Back to [BCO domains](bco-domains.md)_
 
 This section defines the `usability_domain` part of the [BCO](bco-domains.md) structure.
 
-This field provides a space for the author to define the usability domain of the BCO. It is an array of free text values that should be consistant with terminology used in the [`name`](provenance_domain.md#2.1.1-name-name), external references ([xref](/description-domain.md#242-external-references-xref)), and [keywords](/description-domain.md#241-keywords-keywords) sections. The `usability_domain` can accept template language to indicate values from the [external_references](https://github.com/biocompute-objects/BCO_Specification/blob/master/external-references.md). The template takes the form of:
+This field provides a space for the author to define the usability domain of the BCO. It is an array of free text values that should be consistant with terminology used in the [`name`](provenance_domain.md#2.1.1-name-name), external references ([`xref`](/description-domain.md#242-external-references-xref)), and [`keywords`](/description-domain.md#241-keywords-keywords) sections. The `usability_domain` can accept template language to indicate values from the [`external_references`](https://github.com/biocompute-objects/BCO_Specification/blob/master/external-references.md). The template takes the form of:
 * `(SNP)[SO:0000694]` 
 
 where ($term) and [$identifier] are an entry in the `external_references` section.

--- a/usability-domain.md
+++ b/usability-domain.md
@@ -1,14 +1,17 @@
 _This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
+_Back to [BCO domains](bco-domains.md)_
+
 ## 2.2 Usability Domain "usability_domain"
 
-This section defines the fields of the `usability_domain` part of the [BCO](bco-domains.md) structure.
+This section defines the `usability_domain` part of the [BCO](bco-domains.md) structure.
 
-This field provides a space for the author to define the usability domain of the BCO. It is an array of free text values that can accept template language to indicate values from the [external_references](https://github.com/biocompute-objects/BCO_Specification/blob/master/external-references.md). This field is to aid in search-ability and provide a specific **scientific use case** and a description of the function of the object. The usability domain along with keywords can help determine when and how the BCO can be used. It is recomended that a novel use of the BCO could result in the creation of a new entry with a new usability domain. The template takes the form of:
+This field provides a space for the author to define the usability domain of the BCO. It is an array of free text values that should be consistant with terminology used in the [`name`](provenance_domain.md#2.1.1-name-name), external references ([xref](/description-domain.md#242-external-references-xref)), and [keywords](/description-domain.md#241-keywords-keywords) sections. The `usability_domain` can accept template language to indicate values from the [external_references](https://github.com/biocompute-objects/BCO_Specification/blob/master/external-references.md). The template takes the form of:
 * `(SNP)[SO:0000694]` 
 
 where ($term) and [$identifier] are an entry in the `external_references` section.
 
+This field is to aid in search-ability and provide a specific **scientific use case** and a description of the function of the object. The usability domain along with keywords can help determine when and how the BCO can be used. It is recomended that a novel use of a specific BCO would result in the creation of a new entry with a new usability domain.
 
 ```json
     "usability_domain": [

--- a/usability-domain.md
+++ b/usability-domain.md
@@ -1,4 +1,4 @@
-_This document is part of the [BioCompute Object specification](bco-specification.md)_
+_This document is part of the [BioCompute Object User Guide](user_guide.md)_
 
 ## 2.2 Usability Domain "usability_domain"
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -1,6 +1,8 @@
 GitHub: https://github.com/biocompute-objects
 	
-OSF page: https://osf.io/r6s4u/ biocomputeobject.org
+OSF page: https://osf.io/h59uh/ 
+
+BioCompute Partnership: http://biocomputeobject.org
 
 # BioCompute Object (BCO) User Guide
 
@@ -33,7 +35,7 @@ Read more:
 
 BCOs are represented in JSON (JavaScript Object Notation) formatted text, adhearing to [JSON schema draft-07](https://json-schema.org/specification.html). The JSON format was chosen because it is both human and machine readable/writable. For a detailed description of JSON see [www.json.org](http://www.json.org).
 
-BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of creation with actual values compliant to the schema the BCO should be assigned a unique identifier, [`a bco_id`](). The object could then be assigned a unique digital [`checksum`]().
+BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of creation with actual values compliant to the schema the BCO should be assigned a unique identifier, [`a bco_id`](/top-level.md#202-biocompute-object-identifier-bco_id). The object could then be assigned a unique digital [`checksum`](/top-level.md#203-checksum-checksum).
 
 Three of the domains in a BioCompute Object SHOULD become immutable upon assignment of the digital `checksum`: 1) the Parametric Domain, 2) the Execution Domain and 3) the I/O Domain.
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -42,8 +42,6 @@ Three of the domains in a BioCompute Object SHOULD become immutable upon assignm
 2) the Execution Domain and 
 3) the I/O Domain
 
-Specification:
-
 * [BCO domains](bco-domains.md)
 
 # 3 Appendices

--- a/user_guide.md
+++ b/user_guide.md
@@ -29,13 +29,13 @@ Read more:
 
 * [Introduction to BioCompute Objects](introduction.md)
 
-# 2 Data type for BCOs
+# 2 BioCompute Domains
 
-The fundamentals of data typing (type primitives, class inheritance, etc.)  that are used to define BioCompute Objects are described in detail in section Appendix VI. Developers of BCO enabled platforms should reference this section for details on how to support the creation of BCO programmatically or manually. BCOs are represented in JSON (JavaScript Object Notation) formatted text. The JSON format was chosen because it is both human and machine readable/writable. For a detailed description of JSON see [www.json.org](http://www.json.org).
+BCOs are represented in JSON (JavaScript Object Notation) formatted text, adhearing to [JSON schema draft-07](https://json-schema.org/specification.html). The JSON format was chosen because it is both human and machine readable/writable. For a detailed description of JSON see [www.json.org](http://www.json.org).
 
-BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of submission to the BioCompute Object database an instance of BCO type is created, populated with actual values compliant with the data type definitions and assigned a unique identifier. The object could then be assigned a unique digital signature and a unique digital object identifier. (See security section, Appendix V.)
+BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of creation with actual values compliant to the schema the BCO should be assigned a unique identifier, [`a bco_id`](). The object could then be assigned a unique digital [`checksum`]().
 
-Three of the domains in a BioCompute Object become immutable upon assignment of the digital signature: 1) the Parametric Domain, 2) the Execution Domain and 3) the I/O Domain. Changing anything within these domains invalidates the verification and will break the digital signature. Required fields are indicated by the "vital": "True" flag, which is shown in the data typing section below (Appendix VI). 
+Three of the domains in a BioCompute Object SHOULD become immutable upon assignment of the digital `checksum`: 1) the Parametric Domain, 2) the Execution Domain and 3) the I/O Domain.
 
 Specification:
 
@@ -57,9 +57,7 @@ Specifications:
 
 * [External references](external-references.md)
 
-### 3.2.2 Title 21 CFR Part 11
-
-<!-- TODO: Why is this part of 3.2?? -->
+## 3.3 Title 21 CFR Part 11
 
 *Code of Federal Regulations Title 21 Part 11: Electronic Records - Electronic Signatures*
 
@@ -71,24 +69,15 @@ Relevant document link:
 
 [Part 11: Electronic Records](http://www.fda.gov/RegulatoryInformation/Guidances/ucm125067.htm)
 
-## 3.3 Appendix IV - Compatibility
+## 3.4 Appendix IV - Compatibility
 
-### 3.3.1 ISA for the experimental metadata
+### 3.4.1 ISA for the experimental metadata
 
 ISA is a metadata framework to manage an increasingly diverse set of life science, environmental and biomedical experiments that employ one or a combination of technologies. Built around the **Investigation** (the project context), **Study** (a unit of research) and **Assay** (analytical measurements) concepts, ISA helps to provide rich descriptions of experimental metadata (i.e. sample characteristics, technology and measurement types, sample-to-data relationships) so that the resulting data and discoveries are reproducible and reusable. The ISA Model and Serialization Specifications define an Abstract Model of the metadata framework that has been implemented in two format specifications, ISA-Tab and ISA-JSON ([http://isa-tools.org/format/specification](http://isa-tools.org/format/specification)), both of which have supporting tools and services associated with them, including by a programmable Python AP ([http://isa-tools.org](http://isa-tools.org/format/specification)) and a varied user community and contributors ([http://www.isacommons.org](http://www.isacommons.org)). ISA focuses on structuring experimental metadata; raw and derived data files, codes, workflows etc are considered as external file that are referenced. An example, along its complementarity with other models and a computational workflow is illustrated in this paper, which shows how to explicitly declare elements of experimental design, variables, and findings: [http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0127612](http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0127612) 
 
-
-## 3.4 Appendix V Data typing
-
-The conceptual schema for BCO creation can be defined in `???` schema language. <!-- TODO: What to call this language? -->
-
-Specifications:
-
-* [Data Typing](data-typing.md)
-
 ## 3.5 Appendix VI Acknowledgements
 
-This document began development during the 2017 HTS-CSRS workshop. The discussion during the workshop facilitated the refinement and completion of this document. The workshop participants were a major part of the initial BCO community, and the comments and suggestions collected during the sessions were incorporated into this document. The people who participated in the 2017 workshop, and therefore made significant contributions are listed here: [https://osf.io/h59uh/](https://osf.io/h59uh/)
+This document began development during the [2017 HTS-CSRS workshop](https://hive.biochemistry.gwu.edu/htscsrs/workshop_2017). The discussion during the workshop led to the refinement and completion of this document. The workshop participants were a major part of the initial BCO community, and the comments and suggestions collected during the sessions were incorporated into this document. The people who participated in the 2017 workshop, and therefore made significant contributions are listed here: [https://osf.io/h59uh/](https://osf.io/h59uh/)
 
 ### BioCompute Object Consortium members (BCOC)
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -2,7 +2,7 @@ GitHub: https://github.com/biocompute-objects
 	
 OSF page: https://osf.io/r6s4u/ biocomputeobject.org
 
-# BioCompute Object (BCO) specification document
+# BioCompute Object (BCO) User Guide
 
 * This version: [draft](https://github.com/biocompute-objects/BCO_Specification/tree/master)
 * Previous version: [v1.2.0](https://github.com/biocompute-objects/BCO_Specification/releases/tag/v1.2)
@@ -11,8 +11,11 @@ OSF page: https://osf.io/r6s4u/ biocomputeobject.org
 <!-- FIXME: Ideally permalinks for all of the above links, say registering https://w3id.org/bco/ -->
 
 
-<!-- TODO: Authors/editors, IEEE etc -->
-<!-- TODO: License of this document -->
+This document was created by the [BioCompute Object Consortium members (BCOC)](#biocompute-object-consortium-members-bcoc)
+
+### BCO_Specification is licensed under the [BSD 3-Clause "New" or "Revised" License](./LICENSE)
+
+>A permissive license similar to the BSD 2-Clause License, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.
 
 #### High-throughput Sequencing Computational Standards for Regulatory Sciences (HTS-CSRS) Project
 
@@ -20,7 +23,7 @@ This document specifies the structure of BioCompute Objects.
 The specification is split into multiple parts linked to from this 
 top-level document and are maintained in a 
 [GithHub repository](https://github.com/biocompute-objects/BCO_Specification)
-where [contributions](README.md) are welcome.
+where [contributions](README.md#support-community-and-contributing) are welcome.
 
 # 1 Introduction
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -17,15 +17,13 @@ This document was created by the [BioCompute Object Consortium members (BCOC)](#
 
 >A permissive license similar to the BSD 2-Clause License, but with a 3rd clause that prohibits others from using the name of the project or its contributors to promote derived products without written consent.
 
-#### High-throughput Sequencing Computational Standards for Regulatory Sciences (HTS-CSRS) Project
+# 1 Introduction
 
 This document specifies the structure of BioCompute Objects. 
 The specification is split into multiple parts linked to from this 
 top-level document and are maintained in a 
 [GithHub repository](https://github.com/biocompute-objects/BCO_Specification)
 where [contributions](README.md#support-community-and-contributing) are welcome.
-
-# 1 Introduction
 
 Read more:
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -35,7 +35,7 @@ Read more:
 
 BCOs are represented in JSON (JavaScript Object Notation) formatted text, adhearing to [JSON schema draft-07](https://json-schema.org/specification.html). The JSON format was chosen because it is both human and machine readable/writable. For a detailed description of JSON see [www.json.org](http://www.json.org).
 
-BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of creation with actual values compliant to the schema the BCO should be assigned a unique identifier, [`a bco_id`](/top-level.md#202-biocompute-object-identifier-bco_id). The object could then be assigned a unique digital [`checksum`](/top-level.md#203-checksum-checksum).
+BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of creation with actual values compliant to the schema the BCO should be assigned a unique identifier, a [`bco_id`](/top-level.md#202-biocompute-object-identifier-bco_id). The object could then be assigned a unique digital [`checksum`](/top-level.md#203-checksum-checksum).
 
 Three of the domains in a BioCompute Object SHOULD become immutable upon assignment of the digital `checksum`: 1) the Parametric Domain, 2) the Execution Domain and 3) the I/O Domain.
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -37,7 +37,10 @@ BCOs are represented in JSON (JavaScript Object Notation) formatted text, adhear
 
 BioCompute data types are defined as aggregates of the critical fields organized into the following domains: the provenance domain, the usability domain, the extension domain, the description domain, the execution domain, the parametric domain, the input and output domains, and the error domain. At the time of creation with actual values compliant to the schema the BCO should be assigned a unique identifier, a [`bco_id`](/top-level.md#202-biocompute-object-identifier-bco_id). The object could then be assigned a unique digital [`checksum`](/top-level.md#203-checksum-checksum).
 
-Three of the domains in a BioCompute Object SHOULD become immutable upon assignment of the digital `checksum`: 1) the Parametric Domain, 2) the Execution Domain and 3) the I/O Domain.
+Three of the domains in a BioCompute Object SHOULD become immutable upon assignment of the digital `checksum`: 
+1) the Parametric Domain
+2) the Execution Domain and 
+3) the I/O Domain
 
 Specification:
 


### PR DESCRIPTION
schema is valid according to object and @corburn's `validate.py` script. 
>Fixes #5

Define a bco specific `uri` object and update the MD files. 
> this fixes #23 and fixes #48 -> JSON schema validated the `uri` and `access_time`. 

`digital_signature` -> `checksum`
> fixes #43 

removed "Specification" from MD files and renamed as User Guide. 

- Updated the README to reflect User Guide

edits for consistency between schemas and User Guide. 
> fixes #42 and fixes #50 